### PR TITLE
:sparkles: Create template module (#1)

### DIFF
--- a/source/dev-dependencies.ts
+++ b/source/dev-dependencies.ts
@@ -1,0 +1,2 @@
+// @deno-types="npm:@types/chai@latest";
+export { expect } from "npm:chai@5.0.0-alpha.2";

--- a/source/template.test.ts
+++ b/source/template.test.ts
@@ -1,0 +1,129 @@
+import { expect } from "./dev-dependencies.ts";
+import { Template } from "./template.ts";
+
+Deno.test("The constructor of the class Template should initialize the template with the provided value", () => {
+  const template = new Template("Hello {name}");
+
+  expect(`${template}`).to.equal("Hello {name}");
+});
+
+Deno.test("The constructor of the class Template should initialize the template with the provided value even if it doesn't have placeholders", () => {
+  const template = new Template("Hello World");
+
+  expect(`${template}`).to.equal("Hello World");
+});
+
+Deno.test("The constructor of the class Template should initialize the template with the provided value and default replacements", () => {
+  const defaults = { name: "World" };
+  const template = new Template("Hello {name}", defaults);
+
+  expect(`${template}`).to.equal("Hello {name}");
+  expect(template.replacements).to.equal(defaults);
+});
+
+Deno.test("A template instance should be reusable", () => {
+  const template = new Template("Hello {name}");
+
+  const result1 = template.render({ name: "World" });
+  const result2 = template.render({ name: "Y'all" });
+
+  expect(`${template}`).to.equal("Hello {name}");
+  expect(result1).to.equal("Hello World");
+  expect(result2).to.equal("Hello Y'all");
+});
+
+Deno.test("The method template.render() should replace a single placeholder in the template when the replacement value it's a string", () => {
+  const template = new Template("Peace and love on the planet {planet_name}");
+
+  const result = template.render({ planet_name: "Earth" });
+
+  expect(result).to.equal("Peace and love on the planet Earth");
+});
+
+Deno.test("The method template.render() should replace a single placeholder in the template when the replacement value it's a number", () => {
+  const template = new Template(
+    "{number} is the loneliest number that you'll ever do",
+  );
+
+  const result = template.render({ number: 1 });
+
+  expect(result).to.equal("1 is the loneliest number that you'll ever do");
+});
+
+Deno.test("The method template.render() should replace a single placeholder in the template when the replacement value it's a boolean", () => {
+  const template = new Template("It's the {adjective} kinda love");
+
+  const result = template.render({ adjective: true });
+
+  expect(result).to.equal("It's the true kinda love");
+});
+
+Deno.test("The method template.render() should replace multiple unique placeholders", () => {
+  const template = new Template("My name is {first_name} {last_name}");
+
+  const result = template.render({ first_name: "Slim", last_name: "Shady" });
+
+  expect(result).to.equal("My name is Slim Shady");
+});
+
+Deno.test("The method template.render() should replace multiple repeated placeholders", () => {
+  const template = new Template(
+    "Their name is {name}. {name} is {age} years old.",
+  );
+
+  const result = template.render({ name: "Ariel", age: 20 });
+
+  expect(result).to.equal("Their name is Ariel. Ariel is 20 years old.");
+});
+
+Deno.test("The method template.render() should replace placeholders with provided and default replacements", () => {
+  const template = new Template("Hello {name}! My age is {age}.", {
+    name: "Unknown",
+    age: 25,
+  });
+
+  const rendered = template.render({ name: "John" });
+
+  expect(rendered).to.equal("Hello John! My age is 25.");
+});
+
+Deno.test("The method template.render() should replace placeholders with provided and default replacements, with the provided values having priority", () => {
+  const template = new Template("Hello {name}! My age is {age}.", {
+    name: "DefaultName",
+    age: 25,
+  });
+
+  const rendered = template.render({ name: "John", age: 20 });
+
+  expect(rendered).to.equal("Hello John! My age is 20.");
+});
+
+Deno.test("The method template.render() should throw an error if it doesn't receive replacements for all the placeholders", () => {
+  const template = new Template("Hi {name}!");
+
+  try {
+    const result = template.render({});
+    expect(result).not.to.be.a("string");
+  } catch (e) {
+    expect(e).to.be.instanceof(Error);
+  }
+});
+
+Deno.test("The method template.partialRender() should create a new template instance with the placeholders that didn't receive a replacement", () => {
+  const template = new Template("My name is {first_name} {last_name}");
+
+  const result = template.partialRender({ first_name: "Sam" });
+
+  expect(`${result}`).to.equal("My name is Sam {last_name}");
+});
+
+Deno.test("The method template.partialRender() should create a new template instance that carries over the default replacements that are still needed", () => {
+  const template = new Template("My name is {first_name} {last_name}", {
+    first_name: "Unknown",
+    last_name: "Unknown",
+  });
+
+  const result = template.partialRender({ first_name: "Sam" });
+
+  expect(result.replacements).to.deep.equal({ last_name: "Unknown" });
+});

--- a/source/template.ts
+++ b/source/template.ts
@@ -1,0 +1,262 @@
+import {
+  deepMerge,
+  filterKeys,
+} from "https://deno.land/std@0.208.0/collections/mod.ts";
+import { Expand, ObjectEntries, ReplaceAll, UnionToTuple } from "./typings.ts";
+
+/**
+ * Template class that allows rendering a string template with placeholders.
+ *
+ * The template string passed to the constructor can contain placeholders
+ * surrounded by `{}` braces. These placeholders can then be replaced by
+ * calling `render()` and passing an object with keys matching the placeholder names.
+ *
+ * Partial renders are also supported via `partialRender()`.
+ *
+ * @example
+ *
+ * ```ts
+ * import { Template } from "./template.ts";
+ *
+ * const template = new Template("{salute} {name}!");
+ * const rendered = template.render({ salute: "Hello", name: "World" });
+ *
+ * console.assert(rendered === "Hello World!");
+ *
+ * const partial = template.partialRender({ salute: "Bye" });
+ *
+ * console.assert(`${partial}` === "Bye {name}!");
+ * ```
+ */
+export class Template<T extends string> extends String {
+  /**
+   * Regular expression to match placeholder syntax in the template string.
+   * Looks for strings surrounded by `{}` braces.
+   */
+  static readonly placeholderRegex = /{.+?}/g;
+
+  readonly replacements: Template.Replacements<T>;
+
+  /**
+   * Creates a new Template instance with the given template string value.
+   *
+   * @param value - The template string containing placeholders.
+   * @param defaults - Optional object to fallback when not all replacements are given.
+   *
+   * @example
+   *
+   * ```ts
+   * import { Template } from "./template.ts";
+   *
+   * const template = new Template("Hello {name}!");
+   *
+   * console.assert(`${template}` === "Hello {name}!");
+   * ```
+   */
+  public constructor(value: T, defaults?: Template.PartialReplacements<T>) {
+    super(value);
+
+    this.replacements = (defaults || {}) as Template.Replacements<T>;
+  }
+
+  #render(
+    replacements: Template.PartialReplacements<T>,
+    useDefaults = true,
+  ): string {
+    let endValue = new String(this) as string;
+    const rep = useDefaults
+      ? deepMerge(this.replacements, replacements)
+      : replacements;
+
+    for (const key in rep) {
+      const template = `{${key}}`;
+
+      endValue = endValue.replaceAll(template, rep[key] as string);
+    }
+
+    return endValue;
+  }
+
+  #validate(value: string) {
+    const placeholders = Array.from(value.matchAll(Template.placeholderRegex))
+      .map((v) => v[0]);
+
+    if (placeholders.length !== 0) {
+      throw new Error("Some placeholders haven't been replaced yet", {
+        cause: {
+          template: `${this}`,
+          result: value,
+          missingReplacements: placeholders,
+        },
+      });
+    }
+  }
+
+  /**
+   * Renders the template string by replacing placeholders with provided values.
+   *
+   * Loops through the `replacements` object and replaces each placeholder
+   * surrounded by `{}` in the template with the corresponding value.
+   *
+   * @param replacements - Object with keys matching placeholders and substitute values.
+   * @returns Rendered string with all placeholders replaced.
+   *
+   * @example
+   *
+   * ```ts
+   * import { Template } from "./template.ts";
+   *
+   * const template = new Template("Hello {name}!");
+   * const rendered = template.render({name: "World"});
+   *
+   * console.assert(rendered === "Hello World!");
+   * ```
+   */
+  public render(replacements: Template.PartialReplacements<T>): string {
+    const result = this.#render(replacements);
+
+    this.#validate(result);
+
+    return result;
+  }
+
+  /**
+   * Partially renders the template string with the given replacements.
+   *
+   * This creates a new Template instance with the template string rendered with
+   * the provided partial replacements. Any placeholders that were not replaced
+   * will remain in the new template string.
+   *
+   * @param replacements - Partial replacements to apply to the template string
+   * @returns A new Template instance with the partial replacements rendered
+   *
+   * @example
+   *
+   * ```ts
+   * import { Template } from "./template.ts";
+   *
+   * const template = new Template("Hello {name}! My name is {assistant}.");
+   * const partial = template.partialRender({ name: "Human" });
+   *
+   * console.assert(`${partial}` === "Hello Human! My name is {assistant}.");
+   * ```
+   */
+  public partialRender<R extends Template.PartialReplacements<T>>(
+    replacements: R,
+  ) {
+    type NT = Template.ApplyReplacements<T, R>;
+    // @ts-ignore: ¯\_(ツ)_/¯
+    const nt = this.#render(replacements, false) as NT;
+    const defaults = filterKeys(this.replacements, (k) => !(k in replacements));
+
+    return new Template(nt, defaults as Template.Replacements<NT>);
+  }
+}
+
+// deno-lint-ignore no-namespace
+export namespace Template {
+  /**
+   * Type mapping string template placeholders to their
+   * possible replacement values.
+   *
+   * @example
+   *
+   * ```ts
+   * import { Template } from "./template.ts";
+   *
+   * type TemplateString = "Hello {name}!";
+   * const replacements: Template.Replacements<TemplateString> = { name: "Peter" };
+   * ```
+   */
+  export type Replacements<T extends string> = Expand<
+    {
+      [K in ExtractTemplatePlaceholders<T>[number]]: string | number | boolean;
+    }
+  >;
+
+  /**
+   * Same as {@link Template.Replacements} but all properties are marked as optional.
+   */
+  export type PartialReplacements<T extends string> = Partial<Replacements<T>>;
+
+  /**
+   * Represents the application of replacements to a template string.
+   * It takes a template string (`T`) and a set of replacements (`R`) and
+   * produce a new string with the specified replacements applied.
+   *
+   * @param T - A template string.
+   * @param R - An object containing key-value pairs.
+   *
+   * @example
+   *
+   * ```ts
+   * import { Template } from "./template.ts";
+   *
+   * type TemplateString = "Hello {name}!";
+   * type Replacements = { name: "Peter" };
+   * type Result = Template.ApplyReplacements<TemplateString, Replacements>;
+   *
+   * const result: Result = "Hello Peter!";
+   * ```
+   */
+  export type ApplyReplacements<T extends string, R> = UnionToTuple<
+    ObjectEntries<R>
+  > extends ReplacementPair[]
+    ? ReplaceAllInTemplate<T, UnionToTuple<ObjectEntries<R>>>
+    : T;
+
+  /**
+   * @ignore
+   */
+  type ExtractTemplatePlaceholders<
+    T extends string,
+    Cache extends string[] = [],
+  > = T extends MultiPlaceholderTemplate
+    ? T extends `${string}{${infer S}}${infer Rest}`
+      ? ExtractTemplatePlaceholders<Rest, [...Cache, S]>
+    : Cache
+    : Cache;
+
+  /**
+   * @ignore
+   */
+  type ReplacementPair = [string, string | number | boolean];
+
+  /**
+   * @ignore
+   */
+  type ApplyReplacementToTemplate<
+    T extends string,
+    Rep extends ReplacementPair,
+    Cache extends string = T,
+    Templates extends string[] = ExtractTemplatePlaceholders<Cache>,
+  > = Rep[0] extends Templates[number]
+    ? ReplaceAll<T, `{${Rep[0]}}`, `${Rep[1]}`>
+    : T;
+
+  /**
+   * @ignore
+   */
+  type ReplaceAllInTemplate<
+    T extends string,
+    Rep extends ReplacementPair[],
+  > = Rep["length"] extends 0 ? T
+    : Rep extends [infer F, ...infer R]
+      ? F extends ReplacementPair
+        ? R extends ReplacementPair[]
+          ? ReplaceAllInTemplate<ApplyReplacementToTemplate<T, F>, R>
+        : ReplaceAllInTemplate<ApplyReplacementToTemplate<T, F>, []>
+      : T
+    : T;
+
+  /**
+   * @ignore
+   */
+  type SinglePlaceholderTemplate = `{${string}}`;
+
+  /**
+   * @ignore
+   */
+  type MultiPlaceholderTemplate =
+    `${string}${SinglePlaceholderTemplate}${string}`;
+}

--- a/source/typings.ts
+++ b/source/typings.ts
@@ -1,0 +1,70 @@
+/**
+ * Takes a type `T` and expands it into an object type with the same properties as `T`.
+ *
+ * @param T - The type to be expanded.
+ *
+ * @see {@link https://stackoverflow.com/a/69288824/62937 Source}
+ */
+export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+/**
+ * Takes a union type `U` and transforms it into an intersection type.
+ *
+ * @param U - The union type to be transformed.
+ */
+export type UnionToIntersection<U> = (
+  U extends unknown ? (arg: U) => 0 : never
+) extends (arg: infer I) => 0 ? I
+  : never;
+
+/**
+ * Takes a union type `U` and extracts the last type in the union.
+ *
+ * @param U - The union type from which to extract the last type.
+ */
+export type LastInUnion<U> = UnionToIntersection<
+  U extends unknown ? (x: U) => 0 : never
+> extends (x: infer L) => 0 ? L
+  : never;
+
+/**
+ * Takes a union type `U` and transforms it into a tuple type.
+ *
+ * @param U - The union type to be transformed into a tuple.
+ */
+export type UnionToTuple<U, Last = LastInUnion<U>> = [U] extends [never] ? []
+  : [...UnionToTuple<Exclude<U, Last>>, Last];
+
+/**
+ * Takes a type `T` and removes the `undefined` type from its properties.
+ *
+ * @param T - The type from which to remove `undefined`.
+ */
+export type RemoveUndefined<T> = [T] extends [undefined] ? T
+  : Exclude<T, undefined>;
+
+/**
+ * Takes an object type `T` and transforms it into an array of key-value pairs,
+ * where each value has `undefined` removed.
+ *
+ * @param T - The object type from which to extract key-value pairs.
+ */
+export type ObjectEntries<T> = {
+  [K in keyof T]-?: [K, RemoveUndefined<T[K]>];
+}[keyof T];
+
+/**
+ * Takes a string `S` and replaces all occurrences of substring `From` with substring `To`.
+ *
+ * @param S - The string in which to perform replacements.
+ * @param From - The substring to be replaced.
+ * @param To - The substring to replace occurrences of `From`.
+ */
+export type ReplaceAll<
+  S extends string,
+  From extends string,
+  To extends string,
+> = From extends "" ? S
+  : S extends `${infer R1}${From}${infer R2}`
+    ? `${R1}${To}${ReplaceAll<R2, From, To>}`
+  : S;


### PR DESCRIPTION
## Summary

As a developer, I want an efficient way to create and replace string templates, so that I can enhance code readability and maintainability in our project.

## Acceptance Criteria:

- [x] I should be able to define a string template by using placeholders enclosed in a recognizable format, such as curly braces `{}` or any other clear and standard syntax.
- [x] I want the ability to easily replace the placeholders in the string template with actual values by providing a mapping of placeholder names to their corresponding values.
- [x] The solution should support the replacement of placeholders with various data types, including strings, numbers, and booleans.
- [x] The system should handle cases where placeholders are repeated within the same template, ensuring that each occurrence is replaced correctly.
- [x] I need the option to reuse the same string template with different sets of values without modifying the original template.
- [x] It should be possible to create default values for placeholders, allowing for flexibility when some values are not provided during the replacement process.
- [x] The implementation should include error handling to notify me if there are missing placeholders or if the provided values are incompatible with the expected types.
- [x] The solution should be well-documented, providing clear examples and guidelines on how to use the string template creation and replacement functionality.

## Notes

- Closes #1.